### PR TITLE
Add MIT License file to the repository

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -32,6 +32,6 @@ The externally maintained libraries and assets used by 3D-Blockstack are:
 
 SPDX-License-Identifier: MIT
 License-Version: 1.0
-Last-Updated: 2025-01-01
+Last-Updated: 2025-10-14
 
 For questions regarding this license, please contact: maitri-vv


### PR DESCRIPTION
This pull request adds a new `LICENSE` file to the project, specifying the terms under which the software and its components may be used. The project is now explicitly licensed under the MIT License, clarifying permissions and conditions for users and contributors.

Licensing and attribution:

* Added an MIT License to the project, granting broad rights to use, modify, and distribute the software, while disclaiming warranties.
* Included attribution and licensing details for externally maintained libraries and assets used in the project, such as Three.js, WebGL utilities, CSS frameworks, and mathematical algorithms.
* Provided SPDX identifier, license version, last updated date, and contact information for licensing questions.

This PR Fixes #3 