### PR TITLE
[Enhancement] Added camera zoom out functionality when the game ends

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,7 +21,6 @@ body {
 
 /* UI Elements */
 #instructions,
-#results,
 #score,
 #youtube-card {
   position: absolute;
@@ -29,6 +28,17 @@ body {
   color: white;
   text-align: center;
   user-select: none;
+}
+
+#results {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: fit-content;
+  height: auto;
+  max-width: 90vw;
+  padding: 0;
+  /* rest of your styles */
 }
 
 #instructions {


### PR DESCRIPTION
## Pull Request Title 
[Enhancement] Added camera zoom out functionality when the game ends

Examples:
- [Feature]: When the game ends, the camera is zoomed out for the player to look at his blockstacks at a better camera angle. Tween.js is used here to animate the camera movements for a smooth experience.
- [Feature]: Updated the Results display box to appear at the top of the block stack.
- [Feature]: Completely responsive for both big screens (laptop screens) to small screens (mobile phone screens)

## 🎯 What issue does this address?
Closes #5

## ✨ What does this change?
This changes the camera movements of the game and the way user recieves the results after looking at his entire block stack.

## Checklist:
- [ ✅] New functionality meets the goals defined in the linked issue.
- [ ✅] If changing the UI or game experience, screenshots or a GIF are included below.
- [ ✅] Code is formatted cleanly (ran Prettier/ESLint locally).
- [ ✅] All CI/CD checks in this PR passed.
- [ ✅] Game mechanics work correctly (blocks stack, physics behave properly).
- [ ✅] Performance is maintained (no frame drops or lag introduced).
- [ ✅] Mobile/touch controls still function properly.
- [ ✅] Game resets correctly with 'R' key.

## 🧪 Testing
### Steps to Test Locally (for Reviewer):
1. Clone this branch locally.
2. Open `index.html` in your browser.
3. Test core game functionality:
   - Click/tap/spacebar to drop blocks
   - Verify blocks stack properly with physics
   - Test 'R' key to reset game
   - Check mobile touch controls work
4. Verify the changes (e.g., if it's a bug fix, confirm the bug is gone).
5. Check browser console for any new errors or warnings.
6. Test on different screen sizes/devices if UI changes were made.

- Checked all the above steps multiple times and checked the responsiveness of the screen
