### PR TITLE
Fixed the Twitter/X link not clickable on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -339,6 +339,9 @@ window.addEventListener("keydown", (e) => {
 window.addEventListener(
   "touchstart",
   (e) => {
+  if (e.target.closest(".twitter-link")){
+      return;
+    }
     e.preventDefault();
     gameEnded ? startGame() : eventHandler();
   },


### PR DESCRIPTION
The Twitter/X handle on the game-over screen was unclickable on mobile because a global `touchstart` listener would restart the game.

This change updates the event handler to check the tap's target. If the social link is tapped, the default browser action is allowed, and the game does not restart.

## 🎯 What issue does this address?
Closes #42

## 🖼️ Screenshots / Video Preview
before:
<img width="223" height="259" alt="Screenshot 2025-10-17 at 4 43 27 PM" src="https://github.com/user-attachments/assets/d3ffeecd-e63f-4432-a38b-80154ab0ad94" />
after:
<img width="223" height="280" alt="Screenshot 2025-10-17 at 4 43 50 PM" src="https://github.com/user-attachments/assets/cfe5872f-cf34-4d39-a634-a8618a41f2ee" />

