### PR TITLE
button control fixed for mobile and touchscreen devices

### DIFF
--- a/script.js
+++ b/script.js
@@ -545,9 +545,17 @@ document.addEventListener("keydown", (e) => {
 window.addEventListener(
   "touchstart",
   (e) => {
-    if (e.target.closest(".twitter-link")){
+    if (
+      e.target.closest(".twitter-link") ||  // The Twitter link
+      e.target.closest("#muteBtn") ||       // The mute button
+      e.target.closest("#theme-controls") || // The theme buttons container
+      e.target.closest("#close-results")     
+    ) {
+      // If it was, do nothing and let the browser handle the 'click' event
       return;
     }
+
+    // Otherwise, it's a tap for the game
     e.preventDefault();
     gameEnded ? startGame() : eventHandler();
   },


### PR DESCRIPTION
bug: When using the website on mobile devices audio mute button and theme changing button weren't working

### Fix: Enable Button Clicks on Mobile Devices

#### Description
This PR fixes a bug where UI buttons didn’t respond to taps on touch devices (phones/tablets).  
Affected elements:
- Mute button  
- Theme buttons (Default, Night, Sunset)  
- “Close Results” button on Game Over modal  

#### Root Cause
In `script.js`, a global `touchstart` listener used `e.preventDefault()` on every tap to control the game.  
On mobile browsers, this prevented `click` events from firing, breaking button interactivity.

#### Fix
Updated the `window.addEventListener("touchstart", ...)` handler:
---

### ✅ Checklist (Tested on Mobile / Touch Device)

- [x] **Mute Button** toggles sound correctly.  
- [x] **Theme Buttons** change themes as expected.  
- [x] **Close Results** button closes modal.  
- [x] **Game Controls** (taps) still work normally.  
- [x] No accidental block placement when tapping buttons.

---

**Closes:** #66



Inital bug where when clicking on the buttons it restarts the game


https://github.com/user-attachments/assets/6bbc2874-b36f-4352-9728-9b40e4cb0d87



Buttons are fixed in new update 




https://github.com/user-attachments/assets/910a5ee8-2f50-448c-9873-d2748d6523ef


