### PR TITLE
Update git clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 1. **Clone the repository**
    ```bash
-   git clone https://github.com/your-username/3D-Blockstack.git
+   git clone https://github.com/maitri-vv/3D-Blockstack.git
    cd 3D-Blockstack
    ```
 


### PR DESCRIPTION
previously it was asking for username while cloning the repo locally because the link contains "your_username" instead it should consist of the repo owner name which is "maitri-vv"

I have fixed the clone URL now!