### PR TITLE
Add popup with overlap percentage

### DIFF
--- a/Js/script.js
+++ b/Js/script.js
@@ -412,6 +412,10 @@ function splitBlockAndAddNextOneIfOverlaps() {
   const overhangSize = Math.abs(delta);
   const overlap = size - overhangSize;
 
+  const overlapPercent = Math.max(0,Math.round((overlap / size) * 100));
+  showOverlapPopup(overlapPercent);
+
+
   if (overlap > 0) {
     cutBox(top, overlap, size, delta);
     const shift = (overlap / 2 + overhangSize / 2) * Math.sign(delta);
@@ -439,6 +443,29 @@ function splitBlockAndAddNextOneIfOverlaps() {
     missedTheSpot();
   }
 }
+
+// Function to display overlap percentage
+function showOverlapPopup(percent) {
+  const popup = document.getElementById("overlap-popup");
+  popup.textContent = `${percent}%`;
+
+  // Color feedback
+  if (percent >= 90) {
+    popup.style.background = "rgba(0, 128, 0, 0.8)"; // green
+  } else if (percent >= 60) {
+    popup.style.background = "rgba(255, 165, 0, 0.8)"; // orange
+  } else {
+    popup.style.background = "rgba(178, 34, 34, 0.8)"; // red
+  }
+
+  popup.classList.add("show");
+
+  setTimeout(() => {
+    popup.classList.remove("show");
+  }, 1000);
+}
+
+
 
 // Function to handle game over scenario
 function missedTheSpot() {

--- a/css/style.css
+++ b/css/style.css
@@ -412,6 +412,32 @@ body {
   animation: score-pop 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 
+/* Overlop feedback styles */
+#overlap-popup {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-family: 'Segoe UI', sans-serif;
+  font-size: 18px;
+  font-weight: bold;
+  display: none;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+#overlap-popup.show {
+  display: block;
+  opacity: 1;
+  transform: translateX(-50%) scale(1.05);
+}
+
+
+
 #youtube {
   position: absolute;
   bottom: 10px;

--- a/index.html
+++ b/index.html
@@ -94,6 +94,10 @@
   <!-- score box -->
   <div id="score">0</div>
 
+  <!-- overlap feedback box -->
+<div id="overlap-popup">100%</div>
+
+
   <!-- Theme Buttons -->
 <div id="theme-controls">
   <button id="theme-default" class="theme-btn active" data-tooltip="Default Theme">🌅</button>


### PR DESCRIPTION
[Feature]: Add animated overlap popup with color-coded feedback

What does this change? This PR introduces a visual feedback popup that displays the percentage of overlap when a block is placed. The popup:

- Animates in and out smoothly
- Uses color-coded backgrounds (green/orange/red) based on overlap quality
- Enhances player feedback and game clarity
- Integrates cleanly with existing UI and theme styling


🖼️ **Screenshots / Video Preview**
<img width="797" height="629" alt="image" src="https://github.com/user-attachments/assets/d310f362-f00e-452a-adf9-6ca66b248ee1" />

<img width="335" height="558" alt="image" src="https://github.com/user-attachments/assets/e856a89c-baa2-4a08-835b-a326c4e5392f" />

<img width="889" height="534" alt="image" src="https://github.com/user-attachments/assets/058d9111-ee08-4a26-b3c1-f2aff968c8ee" />


## ✅ Checklist (Required)
Please check all boxes that apply and ensure your PR is ready for review.

[x] I have read the project's [CONTRIBUTING.md] guidelines.

[x] My code follows the project's coding style and conventions.

[x] I have performed a self-review of my own code.

[x] My changes generate no new errors or warnings in the browser console.

[x] I have tested my changes locally on the Vercel-simulated environment (if applicable).

[x] For UI changes, I have tested on different screen sizes (responsive design check).

[x] My commit message(s) are clear and descriptive.